### PR TITLE
Bring solarized themes into parity with official

### DIFF
--- a/base16-solarized.dark.xresources
+++ b/base16-solarized.dark.xresources
@@ -18,22 +18,23 @@
 #define base0E #6c71c4
 #define base0F #d33682
 
-*.foreground:   base05
-*.background:   base00
-*.cursorColor:  base05
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*.foreground:  base04
+*.background:  base00
+*.cursorColor: base05
+
+*.color0:      base01
+*.color1:      base08
+*.color2:      base0B
+*.color3:      base0A
+*.color4:      base0D
+*.color5:      base0F
+*.color6:      base0C
+*.color7:      base06
+*.color8:      base00
+*.color9:      base09
+*.color10:     base02
+*.color11:     base03
+*.color12:     base04
+*.color13:     base0E
+*.color14:     base05
+*.color15:     base07

--- a/base16-solarized.light.xresources
+++ b/base16-solarized.light.xresources
@@ -18,22 +18,23 @@
 #define base0E #6c71c4
 #define base0F #d33682
 
-*.foreground:   base02
+*.foreground:   base03
 *.background:   base07
 *.cursorColor:  base02
-*.color0:       base01
+
+*.color0:       base06
 *.color1:       base08
 *.color2:       base0B
 *.color3:       base0A
 *.color4:       base0D
 *.color5:       base0F
 *.color6:       base0C
-*.color7:       base06
-*.color8:       base00
+*.color7:       base01
+*.color8:       base07
 *.color9:       base09
-*.color10:      base02
-*.color11:      base03
-*.color12:      base04
+*.color10:      base05
+*.color11:      base04
+*.color12:      base03
 *.color13:      base0E
-*.color14:      base05
-*.color15:      base07
+*.color14:      base02
+*.color15:      base00


### PR DESCRIPTION
Because the solarized colors from these themes are not organized the
same way as the xresources from the solarized repository, using these
xresources will break themes for programs written against the
xresources in the solarized repository. For example, the solarized theme
for irssi becomes nearly unreadable when using the base16-solarized
xresources.

This commit re-organizes the solarized xresources to match the
xresources from the official solarized repository. As such, this commit
will break the base16-solarized vim theme, and any other themes relying
on base16's version of xresource organization.

With that said, this commit may not be inline with the goals of the
base16 project; however, I wanted to at least start a discussion. In my
testing, I've found the organization from the solarized project to
provide better readability overall, for both themed programs and general
terminal usage, even when applied to other color schemes. For example,
when I copied the assignments from this updated solarized-dark xresource
file to the default-dark xresource file, general terminal readability
improved.

Perhaps this is just a coincidence of my particular environment, but if
not, it might be worth changing.