### PR TITLE
Adds opacity option

### DIFF
--- a/templates/default-256.mustache
+++ b/templates/default-256.mustache
@@ -19,7 +19,11 @@
 #define base0F #{{base0F-hex}}
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -19,7 +19,11 @@
 #define base0F #{{base0F-hex}}
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-3024-256.Xresources
+++ b/xresources/base16-3024-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-3024-256.Xresources
+++ b/xresources/base16-3024-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #cdab53
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-3024.Xresources
+++ b/xresources/base16-3024.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-3024.Xresources
+++ b/xresources/base16-3024.Xresources
@@ -19,7 +19,11 @@
 #define base0F #cdab53
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-apathy-256.Xresources
+++ b/xresources/base16-apathy-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #3E965B
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-apathy-256.Xresources
+++ b/xresources/base16-apathy-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-apathy.Xresources
+++ b/xresources/base16-apathy.Xresources
@@ -19,7 +19,11 @@
 #define base0F #3E965B
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-apathy.Xresources
+++ b/xresources/base16-apathy.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-ashes-256.Xresources
+++ b/xresources/base16-ashes-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-ashes-256.Xresources
+++ b/xresources/base16-ashes-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #C79595
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-ashes.Xresources
+++ b/xresources/base16-ashes.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-ashes.Xresources
+++ b/xresources/base16-ashes.Xresources
@@ -19,7 +19,11 @@
 #define base0F #C79595
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-cave-256.Xresources
+++ b/xresources/base16-atelier-cave-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-cave-256.Xresources
+++ b/xresources/base16-atelier-cave-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #bf40bf
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-cave-light-256.Xresources
+++ b/xresources/base16-atelier-cave-light-256.Xresources
@@ -1,0 +1,54 @@
+! Base16 Atelier Cave
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
+
+#define base00 #efecf4
+#define base01 #e2dfe7
+#define base02 #8b8792
+#define base03 #7e7887
+#define base04 #655f6d
+#define base05 #585260
+#define base06 #26232a
+#define base07 #19171c
+#define base08 #be4678
+#define base09 #aa573c
+#define base0A #a06e3b
+#define base0B #2a9292
+#define base0C #398bc6
+#define base0D #576ddb
+#define base0E #955ae7
+#define base0F #bf40bf
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
+*.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-atelier-cave-light-256.Xresources
+++ b/xresources/base16-atelier-cave-light-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-cave-light.Xresources
+++ b/xresources/base16-atelier-cave-light.Xresources
@@ -1,0 +1,45 @@
+! Base16 Atelier Cave
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
+
+#define base00 #efecf4
+#define base01 #e2dfe7
+#define base02 #8b8792
+#define base03 #7e7887
+#define base04 #655f6d
+#define base05 #585260
+#define base06 #26232a
+#define base07 #19171c
+#define base08 #be4678
+#define base09 #aa573c
+#define base0A #a06e3b
+#define base0B #2a9292
+#define base0C #398bc6
+#define base0D #576ddb
+#define base0E #955ae7
+#define base0F #bf40bf
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-atelier-cave-light.Xresources
+++ b/xresources/base16-atelier-cave-light.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-cave.Xresources
+++ b/xresources/base16-atelier-cave.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-cave.Xresources
+++ b/xresources/base16-atelier-cave.Xresources
@@ -19,7 +19,11 @@
 #define base0F #bf40bf
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-dune-256.Xresources
+++ b/xresources/base16-atelier-dune-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #d43552
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-dune-256.Xresources
+++ b/xresources/base16-atelier-dune-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-dune-light-256.Xresources
+++ b/xresources/base16-atelier-dune-light-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-dune-light-256.Xresources
+++ b/xresources/base16-atelier-dune-light-256.Xresources
@@ -1,25 +1,29 @@
-! Base16 Harmonic16 Light
-! Scheme: Jannik Siebert (https://github.com/janniks)
+! Base16 Atelier Dune
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
 
-#define base00 #f7f9fb
-#define base01 #e5ebf1
-#define base02 #cbd6e2
-#define base03 #aabcce
-#define base04 #627e99
-#define base05 #405c79
-#define base06 #223b54
-#define base07 #0b1c2c
-#define base08 #bf8b56
-#define base09 #bfbf56
-#define base0A #8bbf56
-#define base0B #56bf8b
-#define base0C #568bbf
-#define base0D #8b56bf
-#define base0E #bf568b
-#define base0F #bf5656
+#define base00 #fefbec
+#define base01 #e8e4cf
+#define base02 #a6a28c
+#define base03 #999580
+#define base04 #7d7a68
+#define base05 #6e6b5e
+#define base06 #292824
+#define base07 #20201d
+#define base08 #d73737
+#define base09 #b65611
+#define base0A #ae9513
+#define base0B #60ac39
+#define base0C #1fad83
+#define base0D #6684e1
+#define base0E #b854d4
+#define base0F #d43552
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-dune-light.Xresources
+++ b/xresources/base16-atelier-dune-light.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-dune-light.Xresources
+++ b/xresources/base16-atelier-dune-light.Xresources
@@ -1,0 +1,45 @@
+! Base16 Atelier Dune
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
+
+#define base00 #fefbec
+#define base01 #e8e4cf
+#define base02 #a6a28c
+#define base03 #999580
+#define base04 #7d7a68
+#define base05 #6e6b5e
+#define base06 #292824
+#define base07 #20201d
+#define base08 #d73737
+#define base09 #b65611
+#define base0A #ae9513
+#define base0B #60ac39
+#define base0C #1fad83
+#define base0D #6684e1
+#define base0E #b854d4
+#define base0F #d43552
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-atelier-dune.Xresources
+++ b/xresources/base16-atelier-dune.Xresources
@@ -19,7 +19,11 @@
 #define base0F #d43552
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-dune.Xresources
+++ b/xresources/base16-atelier-dune.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-estuary-256.Xresources
+++ b/xresources/base16-atelier-estuary-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-estuary-256.Xresources
+++ b/xresources/base16-atelier-estuary-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #9d6c7c
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-estuary-light-256.Xresources
+++ b/xresources/base16-atelier-estuary-light-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-estuary-light-256.Xresources
+++ b/xresources/base16-atelier-estuary-light-256.Xresources
@@ -1,25 +1,29 @@
-! Base16 Solar Flare
-! Scheme: Chuck Harmston (https://chuck.harmston.ch)
+! Base16 Atelier Estuary
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
 
-#define base00 #18262F
-#define base01 #222E38
-#define base02 #586875
-#define base03 #667581
-#define base04 #85939E
-#define base05 #A6AFB8
-#define base06 #E8E9ED
-#define base07 #F5F7FA
-#define base08 #EF5253
-#define base09 #E66B2B
-#define base0A #E4B51C
-#define base0B #7CC844
-#define base0C #52CBB0
-#define base0D #33B5E1
-#define base0E #A363D5
-#define base0F #D73C9A
+#define base00 #f4f3ec
+#define base01 #e7e6df
+#define base02 #929181
+#define base03 #878573
+#define base04 #6c6b5a
+#define base05 #5f5e4e
+#define base06 #302f27
+#define base07 #22221b
+#define base08 #ba6236
+#define base09 #ae7313
+#define base0A #a5980d
+#define base0B #7d9726
+#define base0C #5b9d48
+#define base0D #36a166
+#define base0E #5f9182
+#define base0F #9d6c7c
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-estuary-light.Xresources
+++ b/xresources/base16-atelier-estuary-light.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-estuary-light.Xresources
+++ b/xresources/base16-atelier-estuary-light.Xresources
@@ -1,0 +1,45 @@
+! Base16 Atelier Estuary
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
+
+#define base00 #f4f3ec
+#define base01 #e7e6df
+#define base02 #929181
+#define base03 #878573
+#define base04 #6c6b5a
+#define base05 #5f5e4e
+#define base06 #302f27
+#define base07 #22221b
+#define base08 #ba6236
+#define base09 #ae7313
+#define base0A #a5980d
+#define base0B #7d9726
+#define base0C #5b9d48
+#define base0D #36a166
+#define base0E #5f9182
+#define base0F #9d6c7c
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-atelier-estuary.Xresources
+++ b/xresources/base16-atelier-estuary.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-estuary.Xresources
+++ b/xresources/base16-atelier-estuary.Xresources
@@ -19,7 +19,11 @@
 #define base0F #9d6c7c
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-forest-256.Xresources
+++ b/xresources/base16-atelier-forest-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #c33ff3
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-forest-256.Xresources
+++ b/xresources/base16-atelier-forest-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-forest-light-256.Xresources
+++ b/xresources/base16-atelier-forest-light-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-forest-light-256.Xresources
+++ b/xresources/base16-atelier-forest-light-256.Xresources
@@ -1,0 +1,54 @@
+! Base16 Atelier Forest
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
+
+#define base00 #f1efee
+#define base01 #e6e2e0
+#define base02 #a8a19f
+#define base03 #9c9491
+#define base04 #766e6b
+#define base05 #68615e
+#define base06 #2c2421
+#define base07 #1b1918
+#define base08 #f22c40
+#define base09 #df5320
+#define base0A #c38418
+#define base0B #7b9726
+#define base0C #3d97b8
+#define base0D #407ee7
+#define base0E #6666ea
+#define base0F #c33ff3
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
+*.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-atelier-forest-light.Xresources
+++ b/xresources/base16-atelier-forest-light.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-forest-light.Xresources
+++ b/xresources/base16-atelier-forest-light.Xresources
@@ -1,0 +1,45 @@
+! Base16 Atelier Forest
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
+
+#define base00 #f1efee
+#define base01 #e6e2e0
+#define base02 #a8a19f
+#define base03 #9c9491
+#define base04 #766e6b
+#define base05 #68615e
+#define base06 #2c2421
+#define base07 #1b1918
+#define base08 #f22c40
+#define base09 #df5320
+#define base0A #c38418
+#define base0B #7b9726
+#define base0C #3d97b8
+#define base0D #407ee7
+#define base0E #6666ea
+#define base0F #c33ff3
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-atelier-forest.Xresources
+++ b/xresources/base16-atelier-forest.Xresources
@@ -19,7 +19,11 @@
 #define base0F #c33ff3
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-forest.Xresources
+++ b/xresources/base16-atelier-forest.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-heath-256.Xresources
+++ b/xresources/base16-atelier-heath-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-heath-256.Xresources
+++ b/xresources/base16-atelier-heath-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #cc33cc
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-heath-light-256.Xresources
+++ b/xresources/base16-atelier-heath-light-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-heath-light-256.Xresources
+++ b/xresources/base16-atelier-heath-light-256.Xresources
@@ -1,0 +1,54 @@
+! Base16 Atelier Heath
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
+
+#define base00 #f7f3f7
+#define base01 #d8cad8
+#define base02 #ab9bab
+#define base03 #9e8f9e
+#define base04 #776977
+#define base05 #695d69
+#define base06 #292329
+#define base07 #1b181b
+#define base08 #ca402b
+#define base09 #a65926
+#define base0A #bb8a35
+#define base0B #918b3b
+#define base0C #159393
+#define base0D #516aec
+#define base0E #7b59c0
+#define base0F #cc33cc
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
+*.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-atelier-heath-light.Xresources
+++ b/xresources/base16-atelier-heath-light.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-heath-light.Xresources
+++ b/xresources/base16-atelier-heath-light.Xresources
@@ -1,0 +1,45 @@
+! Base16 Atelier Heath
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
+
+#define base00 #f7f3f7
+#define base01 #d8cad8
+#define base02 #ab9bab
+#define base03 #9e8f9e
+#define base04 #776977
+#define base05 #695d69
+#define base06 #292329
+#define base07 #1b181b
+#define base08 #ca402b
+#define base09 #a65926
+#define base0A #bb8a35
+#define base0B #918b3b
+#define base0C #159393
+#define base0D #516aec
+#define base0E #7b59c0
+#define base0F #cc33cc
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-atelier-heath.Xresources
+++ b/xresources/base16-atelier-heath.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-heath.Xresources
+++ b/xresources/base16-atelier-heath.Xresources
@@ -19,7 +19,11 @@
 #define base0F #cc33cc
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-lakeside-256.Xresources
+++ b/xresources/base16-atelier-lakeside-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-lakeside-256.Xresources
+++ b/xresources/base16-atelier-lakeside-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #b72dd2
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-lakeside-light-256.Xresources
+++ b/xresources/base16-atelier-lakeside-light-256.Xresources
@@ -1,25 +1,29 @@
-! Base16 Green Screen
-! Scheme: Chris Kempson (http://chriskempson.com)
+! Base16 Atelier Lakeside
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
 
-#define base00 #001100
-#define base01 #003300
-#define base02 #005500
-#define base03 #007700
-#define base04 #009900
-#define base05 #00bb00
-#define base06 #00dd00
-#define base07 #00ff00
-#define base08 #007700
-#define base09 #009900
-#define base0A #007700
-#define base0B #00bb00
-#define base0C #005500
-#define base0D #009900
-#define base0E #00bb00
-#define base0F #005500
+#define base00 #ebf8ff
+#define base01 #c1e4f6
+#define base02 #7ea2b4
+#define base03 #7195a8
+#define base04 #5a7b8c
+#define base05 #516d7b
+#define base06 #1f292e
+#define base07 #161b1d
+#define base08 #d22d72
+#define base09 #935c25
+#define base0A #8a8a0f
+#define base0B #568c3b
+#define base0C #2d8f6f
+#define base0D #257fad
+#define base0E #6b6bb8
+#define base0F #b72dd2
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-lakeside-light-256.Xresources
+++ b/xresources/base16-atelier-lakeside-light-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-lakeside-light.Xresources
+++ b/xresources/base16-atelier-lakeside-light.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-lakeside-light.Xresources
+++ b/xresources/base16-atelier-lakeside-light.Xresources
@@ -1,0 +1,45 @@
+! Base16 Atelier Lakeside
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
+
+#define base00 #ebf8ff
+#define base01 #c1e4f6
+#define base02 #7ea2b4
+#define base03 #7195a8
+#define base04 #5a7b8c
+#define base05 #516d7b
+#define base06 #1f292e
+#define base07 #161b1d
+#define base08 #d22d72
+#define base09 #935c25
+#define base0A #8a8a0f
+#define base0B #568c3b
+#define base0C #2d8f6f
+#define base0D #257fad
+#define base0E #6b6bb8
+#define base0F #b72dd2
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-atelier-lakeside.Xresources
+++ b/xresources/base16-atelier-lakeside.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-lakeside.Xresources
+++ b/xresources/base16-atelier-lakeside.Xresources
@@ -19,7 +19,11 @@
 #define base0F #b72dd2
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-plateau-256.Xresources
+++ b/xresources/base16-atelier-plateau-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #bd5187
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-plateau-256.Xresources
+++ b/xresources/base16-atelier-plateau-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-plateau-light-256.Xresources
+++ b/xresources/base16-atelier-plateau-light-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-plateau-light-256.Xresources
+++ b/xresources/base16-atelier-plateau-light-256.Xresources
@@ -1,0 +1,54 @@
+! Base16 Atelier Plateau
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
+
+#define base00 #f4ecec
+#define base01 #e7dfdf
+#define base02 #8a8585
+#define base03 #7e7777
+#define base04 #655d5d
+#define base05 #585050
+#define base06 #292424
+#define base07 #1b1818
+#define base08 #ca4949
+#define base09 #b45a3c
+#define base0A #a06e3b
+#define base0B #4b8b8b
+#define base0C #5485b6
+#define base0D #7272ca
+#define base0E #8464c4
+#define base0F #bd5187
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
+*.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-atelier-plateau-light.Xresources
+++ b/xresources/base16-atelier-plateau-light.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-plateau-light.Xresources
+++ b/xresources/base16-atelier-plateau-light.Xresources
@@ -1,0 +1,45 @@
+! Base16 Atelier Plateau
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
+
+#define base00 #f4ecec
+#define base01 #e7dfdf
+#define base02 #8a8585
+#define base03 #7e7777
+#define base04 #655d5d
+#define base05 #585050
+#define base06 #292424
+#define base07 #1b1818
+#define base08 #ca4949
+#define base09 #b45a3c
+#define base0A #a06e3b
+#define base0B #4b8b8b
+#define base0C #5485b6
+#define base0D #7272ca
+#define base0E #8464c4
+#define base0F #bd5187
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-atelier-plateau.Xresources
+++ b/xresources/base16-atelier-plateau.Xresources
@@ -19,7 +19,11 @@
 #define base0F #bd5187
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-plateau.Xresources
+++ b/xresources/base16-atelier-plateau.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-savanna-256.Xresources
+++ b/xresources/base16-atelier-savanna-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-savanna-256.Xresources
+++ b/xresources/base16-atelier-savanna-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #867469
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-savanna-light-256.Xresources
+++ b/xresources/base16-atelier-savanna-light-256.Xresources
@@ -1,0 +1,54 @@
+! Base16 Atelier Savanna
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
+
+#define base00 #ecf4ee
+#define base01 #dfe7e2
+#define base02 #87928a
+#define base03 #78877d
+#define base04 #5f6d64
+#define base05 #526057
+#define base06 #232a25
+#define base07 #171c19
+#define base08 #b16139
+#define base09 #9f713c
+#define base0A #a07e3b
+#define base0B #489963
+#define base0C #1c9aa0
+#define base0D #478c90
+#define base0E #55859b
+#define base0F #867469
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
+*.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-atelier-savanna-light-256.Xresources
+++ b/xresources/base16-atelier-savanna-light-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-savanna-light.Xresources
+++ b/xresources/base16-atelier-savanna-light.Xresources
@@ -1,0 +1,45 @@
+! Base16 Atelier Savanna
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
+
+#define base00 #ecf4ee
+#define base01 #dfe7e2
+#define base02 #87928a
+#define base03 #78877d
+#define base04 #5f6d64
+#define base05 #526057
+#define base06 #232a25
+#define base07 #171c19
+#define base08 #b16139
+#define base09 #9f713c
+#define base0A #a07e3b
+#define base0B #489963
+#define base0C #1c9aa0
+#define base0D #478c90
+#define base0E #55859b
+#define base0F #867469
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-atelier-savanna-light.Xresources
+++ b/xresources/base16-atelier-savanna-light.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-savanna.Xresources
+++ b/xresources/base16-atelier-savanna.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-savanna.Xresources
+++ b/xresources/base16-atelier-savanna.Xresources
@@ -19,7 +19,11 @@
 #define base0F #867469
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-seaside-256.Xresources
+++ b/xresources/base16-atelier-seaside-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-seaside-256.Xresources
+++ b/xresources/base16-atelier-seaside-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #e619c3
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-seaside-light-256.Xresources
+++ b/xresources/base16-atelier-seaside-light-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-seaside-light-256.Xresources
+++ b/xresources/base16-atelier-seaside-light-256.Xresources
@@ -1,0 +1,54 @@
+! Base16 Atelier Seaside
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
+
+#define base00 #f4fbf4
+#define base01 #cfe8cf
+#define base02 #8ca68c
+#define base03 #809980
+#define base04 #687d68
+#define base05 #5e6e5e
+#define base06 #242924
+#define base07 #131513
+#define base08 #e6193c
+#define base09 #87711d
+#define base0A #98981b
+#define base0B #29a329
+#define base0C #1999b3
+#define base0D #3d62f5
+#define base0E #ad2bee
+#define base0F #e619c3
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
+*.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-atelier-seaside-light.Xresources
+++ b/xresources/base16-atelier-seaside-light.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-seaside-light.Xresources
+++ b/xresources/base16-atelier-seaside-light.Xresources
@@ -1,0 +1,45 @@
+! Base16 Atelier Seaside
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
+
+#define base00 #f4fbf4
+#define base01 #cfe8cf
+#define base02 #8ca68c
+#define base03 #809980
+#define base04 #687d68
+#define base05 #5e6e5e
+#define base06 #242924
+#define base07 #131513
+#define base08 #e6193c
+#define base09 #87711d
+#define base0A #98981b
+#define base0B #29a329
+#define base0C #1999b3
+#define base0D #3d62f5
+#define base0E #ad2bee
+#define base0F #e619c3
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-atelier-seaside.Xresources
+++ b/xresources/base16-atelier-seaside.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-seaside.Xresources
+++ b/xresources/base16-atelier-seaside.Xresources
@@ -19,7 +19,11 @@
 #define base0F #e619c3
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-sulphurpool-256.Xresources
+++ b/xresources/base16-atelier-sulphurpool-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-sulphurpool-256.Xresources
+++ b/xresources/base16-atelier-sulphurpool-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #9c637a
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-atelier-sulphurpool-light-256.Xresources
+++ b/xresources/base16-atelier-sulphurpool-light-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-sulphurpool-light-256.Xresources
+++ b/xresources/base16-atelier-sulphurpool-light-256.Xresources
@@ -1,0 +1,54 @@
+! Base16 Atelier Sulphurpool
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
+
+#define base00 #f5f7ff
+#define base01 #dfe2f1
+#define base02 #979db4
+#define base03 #898ea4
+#define base04 #6b7394
+#define base05 #5e6687
+#define base06 #293256
+#define base07 #202746
+#define base08 #c94922
+#define base09 #c76b29
+#define base0A #c08b30
+#define base0B #ac9739
+#define base0C #22a2c9
+#define base0D #3d8fd1
+#define base0E #6679cc
+#define base0F #9c637a
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
+*.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-atelier-sulphurpool-light.Xresources
+++ b/xresources/base16-atelier-sulphurpool-light.Xresources
@@ -1,0 +1,45 @@
+! Base16 Atelier Sulphurpool
+! Scheme: Bram de Haan (http://atelierbramdehaan.nl)
+
+#define base00 #f5f7ff
+#define base01 #dfe2f1
+#define base02 #979db4
+#define base03 #898ea4
+#define base04 #6b7394
+#define base05 #5e6687
+#define base06 #293256
+#define base07 #202746
+#define base08 #c94922
+#define base09 #c76b29
+#define base0A #c08b30
+#define base0B #ac9739
+#define base0C #22a2c9
+#define base0D #3d8fd1
+#define base0E #6679cc
+#define base0F #9c637a
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-atelier-sulphurpool-light.Xresources
+++ b/xresources/base16-atelier-sulphurpool-light.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-sulphurpool.Xresources
+++ b/xresources/base16-atelier-sulphurpool.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-atelier-sulphurpool.Xresources
+++ b/xresources/base16-atelier-sulphurpool.Xresources
@@ -19,7 +19,11 @@
 #define base0F #9c637a
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-bespin-256.Xresources
+++ b/xresources/base16-bespin-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #937121
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-bespin-256.Xresources
+++ b/xresources/base16-bespin-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-bespin.Xresources
+++ b/xresources/base16-bespin.Xresources
@@ -19,7 +19,11 @@
 #define base0F #937121
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-bespin.Xresources
+++ b/xresources/base16-bespin.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-brewer-256.Xresources
+++ b/xresources/base16-brewer-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #b15928
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-brewer-256.Xresources
+++ b/xresources/base16-brewer-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-brewer.Xresources
+++ b/xresources/base16-brewer.Xresources
@@ -19,7 +19,11 @@
 #define base0F #b15928
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-brewer.Xresources
+++ b/xresources/base16-brewer.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-bright-256.Xresources
+++ b/xresources/base16-bright-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-bright-256.Xresources
+++ b/xresources/base16-bright-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #be643c
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-bright.Xresources
+++ b/xresources/base16-bright.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-bright.Xresources
+++ b/xresources/base16-bright.Xresources
@@ -19,7 +19,11 @@
 #define base0F #be643c
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-chalk-256.Xresources
+++ b/xresources/base16-chalk-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-chalk-256.Xresources
+++ b/xresources/base16-chalk-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #deaf8f
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-chalk.Xresources
+++ b/xresources/base16-chalk.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-chalk.Xresources
+++ b/xresources/base16-chalk.Xresources
@@ -19,7 +19,11 @@
 #define base0F #deaf8f
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-codeschool-256.Xresources
+++ b/xresources/base16-codeschool-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #c98344
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-codeschool-256.Xresources
+++ b/xresources/base16-codeschool-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-codeschool.Xresources
+++ b/xresources/base16-codeschool.Xresources
@@ -19,7 +19,11 @@
 #define base0F #c98344
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-codeschool.Xresources
+++ b/xresources/base16-codeschool.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-cupcake-256.Xresources
+++ b/xresources/base16-cupcake-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-cupcake-256.Xresources
+++ b/xresources/base16-cupcake-256.Xresources
@@ -1,25 +1,29 @@
-! Base16 Seti UI
-! Scheme: 
+! Base16 Cupcake
+! Scheme: Chris Kempson (http://chriskempson.com)
 
-#define base00 #151718
-#define base01 #8ec43d
-#define base02 #3B758C
-#define base03 #41535B
-#define base04 #43a5d5
-#define base05 #d6d6d6
-#define base06 #eeeeee
-#define base07 #ffffff
-#define base08 #Cd3f45
-#define base09 #db7b55
-#define base0A #e6cd69
-#define base0B #9fca56
-#define base0C #55dbbe
-#define base0D #55b5db
-#define base0E #a074c4
-#define base0F #8a553f
+#define base00 #fbf1f2
+#define base01 #f2f1f4
+#define base02 #d8d5dd
+#define base03 #bfb9c6
+#define base04 #a59daf
+#define base05 #8b8198
+#define base06 #72677E
+#define base07 #585062
+#define base08 #D57E85
+#define base09 #EBB790
+#define base0A #DCB16C
+#define base0B #A3B367
+#define base0C #69A9A7
+#define base0D #7297B9
+#define base0E #BB99B4
+#define base0F #BAA58C
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-cupcake.Xresources
+++ b/xresources/base16-cupcake.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-cupcake.Xresources
+++ b/xresources/base16-cupcake.Xresources
@@ -1,0 +1,45 @@
+! Base16 Cupcake
+! Scheme: Chris Kempson (http://chriskempson.com)
+
+#define base00 #fbf1f2
+#define base01 #f2f1f4
+#define base02 #d8d5dd
+#define base03 #bfb9c6
+#define base04 #a59daf
+#define base05 #8b8198
+#define base06 #72677E
+#define base07 #585062
+#define base08 #D57E85
+#define base09 #EBB790
+#define base0A #DCB16C
+#define base0B #A3B367
+#define base0C #69A9A7
+#define base0D #7297B9
+#define base0E #BB99B4
+#define base0F #BAA58C
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-darktooth-256.Xresources
+++ b/xresources/base16-darktooth-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-darktooth-256.Xresources
+++ b/xresources/base16-darktooth-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #A87322
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-darktooth.Xresources
+++ b/xresources/base16-darktooth.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-darktooth.Xresources
+++ b/xresources/base16-darktooth.Xresources
@@ -19,7 +19,11 @@
 #define base0F #A87322
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-default-dark-256.Xresources
+++ b/xresources/base16-default-dark-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-default-dark-256.Xresources
+++ b/xresources/base16-default-dark-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #a16946
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-default-dark.Xresources
+++ b/xresources/base16-default-dark.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-default-dark.Xresources
+++ b/xresources/base16-default-dark.Xresources
@@ -19,7 +19,11 @@
 #define base0F #a16946
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-default-light-256.Xresources
+++ b/xresources/base16-default-light-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-default-light-256.Xresources
+++ b/xresources/base16-default-light-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #a16946
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-default-light.Xresources
+++ b/xresources/base16-default-light.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-default-light.Xresources
+++ b/xresources/base16-default-light.Xresources
@@ -19,7 +19,11 @@
 #define base0F #a16946
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-dracula-256.Xresources
+++ b/xresources/base16-dracula-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-dracula-256.Xresources
+++ b/xresources/base16-dracula-256.Xresources
@@ -1,0 +1,54 @@
+! Base16 Dracula
+! Scheme: Mike Barkmin (http://github.com/mikebarkmin) based on Dracula Theme (http://github.com/dracula)
+
+#define base00 #282936
+#define base01 #3a3c4e
+#define base02 #4d4f68
+#define base03 #626483
+#define base04 #62d6e8
+#define base05 #e9e9f4
+#define base06 #f1f2f8
+#define base07 #f7f7fb
+#define base08 #ea51b2
+#define base09 #b45bcf
+#define base0A #00f769
+#define base0B #ebff87
+#define base0C #a1efe4
+#define base0D #62d6e8
+#define base0E #b45bcf
+#define base0F #00f769
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
+*.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-dracula.Xresources
+++ b/xresources/base16-dracula.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-dracula.Xresources
+++ b/xresources/base16-dracula.Xresources
@@ -1,0 +1,45 @@
+! Base16 Dracula
+! Scheme: Mike Barkmin (http://github.com/mikebarkmin) based on Dracula Theme (http://github.com/dracula)
+
+#define base00 #282936
+#define base01 #3a3c4e
+#define base02 #4d4f68
+#define base03 #626483
+#define base04 #62d6e8
+#define base05 #e9e9f4
+#define base06 #f1f2f8
+#define base07 #f7f7fb
+#define base08 #ea51b2
+#define base09 #b45bcf
+#define base0A #00f769
+#define base0B #ebff87
+#define base0C #a1efe4
+#define base0D #62d6e8
+#define base0E #b45bcf
+#define base0F #00f769
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-eighties-256.Xresources
+++ b/xresources/base16-eighties-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-eighties-256.Xresources
+++ b/xresources/base16-eighties-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #d27b53
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-eighties.Xresources
+++ b/xresources/base16-eighties.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-eighties.Xresources
+++ b/xresources/base16-eighties.Xresources
@@ -19,7 +19,11 @@
 #define base0F #d27b53
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-embers-256.Xresources
+++ b/xresources/base16-embers-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-embers-256.Xresources
+++ b/xresources/base16-embers-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #825757
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-embers.Xresources
+++ b/xresources/base16-embers.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-embers.Xresources
+++ b/xresources/base16-embers.Xresources
@@ -19,7 +19,11 @@
 #define base0F #825757
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-flat-256.Xresources
+++ b/xresources/base16-flat-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-flat-256.Xresources
+++ b/xresources/base16-flat-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #be643c
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-flat.Xresources
+++ b/xresources/base16-flat.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-flat.Xresources
+++ b/xresources/base16-flat.Xresources
@@ -19,7 +19,11 @@
 #define base0F #be643c
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-github-256.Xresources
+++ b/xresources/base16-github-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #333333
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-github-256.Xresources
+++ b/xresources/base16-github-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-github.Xresources
+++ b/xresources/base16-github.Xresources
@@ -19,7 +19,11 @@
 #define base0F #333333
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-github.Xresources
+++ b/xresources/base16-github.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-google-dark-256.Xresources
+++ b/xresources/base16-google-dark-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-google-dark-256.Xresources
+++ b/xresources/base16-google-dark-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #3971ED
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-google-dark.Xresources
+++ b/xresources/base16-google-dark.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-google-dark.Xresources
+++ b/xresources/base16-google-dark.Xresources
@@ -19,7 +19,11 @@
 #define base0F #3971ED
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-google-light-256.Xresources
+++ b/xresources/base16-google-light-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-google-light-256.Xresources
+++ b/xresources/base16-google-light-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #3971ED
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-google-light.Xresources
+++ b/xresources/base16-google-light.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-google-light.Xresources
+++ b/xresources/base16-google-light.Xresources
@@ -19,7 +19,11 @@
 #define base0F #3971ED
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-grayscale-dark-256.Xresources
+++ b/xresources/base16-grayscale-dark-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-grayscale-dark-256.Xresources
+++ b/xresources/base16-grayscale-dark-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #5e5e5e
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-grayscale-dark.Xresources
+++ b/xresources/base16-grayscale-dark.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-grayscale-dark.Xresources
+++ b/xresources/base16-grayscale-dark.Xresources
@@ -19,7 +19,11 @@
 #define base0F #5e5e5e
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-grayscale-light-256.Xresources
+++ b/xresources/base16-grayscale-light-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-grayscale-light-256.Xresources
+++ b/xresources/base16-grayscale-light-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #5e5e5e
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-grayscale-light.Xresources
+++ b/xresources/base16-grayscale-light.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-grayscale-light.Xresources
+++ b/xresources/base16-grayscale-light.Xresources
@@ -19,7 +19,11 @@
 #define base0F #5e5e5e
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-greenscreen-256.Xresources
+++ b/xresources/base16-greenscreen-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-greenscreen-256.Xresources
+++ b/xresources/base16-greenscreen-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #005500
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00
@@ -32,10 +36,19 @@
 *.color7:       base05
 
 *.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
 *.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-greenscreen.Xresources
+++ b/xresources/base16-greenscreen.Xresources
@@ -1,0 +1,45 @@
+! Base16 Green Screen
+! Scheme: Chris Kempson (http://chriskempson.com)
+
+#define base00 #001100
+#define base01 #003300
+#define base02 #005500
+#define base03 #007700
+#define base04 #009900
+#define base05 #00bb00
+#define base06 #00dd00
+#define base07 #00ff00
+#define base08 #007700
+#define base09 #009900
+#define base0A #007700
+#define base0B #00bb00
+#define base0C #005500
+#define base0D #009900
+#define base0E #00bb00
+#define base0F #005500
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-greenscreen.Xresources
+++ b/xresources/base16-greenscreen.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-gruvbox-dark-hard-256.Xresources
+++ b/xresources/base16-gruvbox-dark-hard-256.Xresources
@@ -1,25 +1,29 @@
-! Base16 Harmonic16 Dark
-! Scheme: Jannik Siebert (https://github.com/janniks)
+! Base16 Gruvbox dark, hard
+! Scheme: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 
-#define base00 #0b1c2c
-#define base01 #223b54
-#define base02 #405c79
-#define base03 #627e99
-#define base04 #aabcce
-#define base05 #cbd6e2
-#define base06 #e5ebf1
-#define base07 #f7f9fb
-#define base08 #bf8b56
-#define base09 #bfbf56
-#define base0A #8bbf56
-#define base0B #56bf8b
-#define base0C #568bbf
-#define base0D #8b56bf
-#define base0E #bf568b
-#define base0F #bf5656
+#define base00 #1d2021
+#define base01 #3c3836
+#define base02 #504945
+#define base03 #665c54
+#define base04 #bdae93
+#define base05 #d5c4a1
+#define base06 #ebdbb2
+#define base07 #fbf1c7
+#define base08 #fb4934
+#define base09 #fe8019
+#define base0A #fabd2f
+#define base0B #b8bb26
+#define base0C #8ec07c
+#define base0D #83a598
+#define base0E #d3869b
+#define base0F #d65d0e
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-gruvbox-dark-hard-256.Xresources
+++ b/xresources/base16-gruvbox-dark-hard-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-gruvbox-dark-hard.Xresources
+++ b/xresources/base16-gruvbox-dark-hard.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-gruvbox-dark-hard.Xresources
+++ b/xresources/base16-gruvbox-dark-hard.Xresources
@@ -1,0 +1,45 @@
+! Base16 Gruvbox dark, hard
+! Scheme: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+
+#define base00 #1d2021
+#define base01 #3c3836
+#define base02 #504945
+#define base03 #665c54
+#define base04 #bdae93
+#define base05 #d5c4a1
+#define base06 #ebdbb2
+#define base07 #fbf1c7
+#define base08 #fb4934
+#define base09 #fe8019
+#define base0A #fabd2f
+#define base0B #b8bb26
+#define base0C #8ec07c
+#define base0D #83a598
+#define base0E #d3869b
+#define base0F #d65d0e
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-gruvbox-dark-medium-256.Xresources
+++ b/xresources/base16-gruvbox-dark-medium-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-gruvbox-dark-medium-256.Xresources
+++ b/xresources/base16-gruvbox-dark-medium-256.Xresources
@@ -1,0 +1,54 @@
+! Base16 Gruvbox dark, medium
+! Scheme: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+
+#define base00 #282828
+#define base01 #3c3836
+#define base02 #504945
+#define base03 #665c54
+#define base04 #bdae93
+#define base05 #d5c4a1
+#define base06 #ebdbb2
+#define base07 #fbf1c7
+#define base08 #fb4934
+#define base09 #fe8019
+#define base0A #fabd2f
+#define base0B #b8bb26
+#define base0C #8ec07c
+#define base0D #83a598
+#define base0E #d3869b
+#define base0F #d65d0e
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
+*.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-gruvbox-dark-medium.Xresources
+++ b/xresources/base16-gruvbox-dark-medium.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-gruvbox-dark-medium.Xresources
+++ b/xresources/base16-gruvbox-dark-medium.Xresources
@@ -1,0 +1,45 @@
+! Base16 Gruvbox dark, medium
+! Scheme: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+
+#define base00 #282828
+#define base01 #3c3836
+#define base02 #504945
+#define base03 #665c54
+#define base04 #bdae93
+#define base05 #d5c4a1
+#define base06 #ebdbb2
+#define base07 #fbf1c7
+#define base08 #fb4934
+#define base09 #fe8019
+#define base0A #fabd2f
+#define base0B #b8bb26
+#define base0C #8ec07c
+#define base0D #83a598
+#define base0E #d3869b
+#define base0F #d65d0e
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-gruvbox-dark-pale-256.Xresources
+++ b/xresources/base16-gruvbox-dark-pale-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-gruvbox-dark-pale-256.Xresources
+++ b/xresources/base16-gruvbox-dark-pale-256.Xresources
@@ -1,25 +1,29 @@
-! Base16 London Tube
-! Scheme: Jan T. Sott
+! Base16 Gruvbox dark, pale
+! Scheme: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 
-#define base00 #231f20
-#define base01 #1c3f95
-#define base02 #5a5758
-#define base03 #737171
-#define base04 #959ca1
-#define base05 #d9d8d8
-#define base06 #e7e7e8
-#define base07 #ffffff
-#define base08 #ee2e24
-#define base09 #f386a1
-#define base0A #ffd204
-#define base0B #00853e
-#define base0C #85cebc
-#define base0D #009ddc
-#define base0E #98005d
-#define base0F #b06110
+#define base00 #262626
+#define base01 #3a3a3a
+#define base02 #4e4e4e
+#define base03 #8a8a8a
+#define base04 #949494
+#define base05 #dab997
+#define base06 #d5c4a1
+#define base07 #ebdbb2
+#define base08 #d75f5f
+#define base09 #ff8700
+#define base0A #ffaf00
+#define base0B #afaf00
+#define base0C #85ad85
+#define base0D #83adad
+#define base0E #d485ad
+#define base0F #d65d0e
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-gruvbox-dark-pale.Xresources
+++ b/xresources/base16-gruvbox-dark-pale.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-gruvbox-dark-pale.Xresources
+++ b/xresources/base16-gruvbox-dark-pale.Xresources
@@ -1,0 +1,45 @@
+! Base16 Gruvbox dark, pale
+! Scheme: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+
+#define base00 #262626
+#define base01 #3a3a3a
+#define base02 #4e4e4e
+#define base03 #8a8a8a
+#define base04 #949494
+#define base05 #dab997
+#define base06 #d5c4a1
+#define base07 #ebdbb2
+#define base08 #d75f5f
+#define base09 #ff8700
+#define base0A #ffaf00
+#define base0B #afaf00
+#define base0C #85ad85
+#define base0D #83adad
+#define base0E #d485ad
+#define base0F #d65d0e
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-gruvbox-dark-soft-256.Xresources
+++ b/xresources/base16-gruvbox-dark-soft-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-gruvbox-dark-soft-256.Xresources
+++ b/xresources/base16-gruvbox-dark-soft-256.Xresources
@@ -1,0 +1,54 @@
+! Base16 Gruvbox dark, soft
+! Scheme: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+
+#define base00 #32302f
+#define base01 #3c3836
+#define base02 #504945
+#define base03 #665c54
+#define base04 #bdae93
+#define base05 #d5c4a1
+#define base06 #ebdbb2
+#define base07 #fbf1c7
+#define base08 #fb4934
+#define base09 #fe8019
+#define base0A #fabd2f
+#define base0B #b8bb26
+#define base0C #8ec07c
+#define base0D #83a598
+#define base0E #d3869b
+#define base0F #d65d0e
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
+*.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-gruvbox-dark-soft.Xresources
+++ b/xresources/base16-gruvbox-dark-soft.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-gruvbox-dark-soft.Xresources
+++ b/xresources/base16-gruvbox-dark-soft.Xresources
@@ -1,0 +1,45 @@
+! Base16 Gruvbox dark, soft
+! Scheme: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+
+#define base00 #32302f
+#define base01 #3c3836
+#define base02 #504945
+#define base03 #665c54
+#define base04 #bdae93
+#define base05 #d5c4a1
+#define base06 #ebdbb2
+#define base07 #fbf1c7
+#define base08 #fb4934
+#define base09 #fe8019
+#define base0A #fabd2f
+#define base0B #b8bb26
+#define base0C #8ec07c
+#define base0D #83a598
+#define base0E #d3869b
+#define base0F #d65d0e
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-gruvbox-light-hard-256.Xresources
+++ b/xresources/base16-gruvbox-light-hard-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-gruvbox-light-hard-256.Xresources
+++ b/xresources/base16-gruvbox-light-hard-256.Xresources
@@ -1,0 +1,54 @@
+! Base16 Gruvbox light, hard
+! Scheme: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+
+#define base00 #f9f5d7
+#define base01 #ebdbb2
+#define base02 #d5c4a1
+#define base03 #bdae93
+#define base04 #665c54
+#define base05 #504945
+#define base06 #3c3836
+#define base07 #282828
+#define base08 #9d0006
+#define base09 #af3a03
+#define base0A #b57614
+#define base0B #79740e
+#define base0C #427b58
+#define base0D #076678
+#define base0E #8f3f71
+#define base0F #d65d0e
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
+*.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-gruvbox-light-hard.Xresources
+++ b/xresources/base16-gruvbox-light-hard.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-gruvbox-light-hard.Xresources
+++ b/xresources/base16-gruvbox-light-hard.Xresources
@@ -1,0 +1,45 @@
+! Base16 Gruvbox light, hard
+! Scheme: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+
+#define base00 #f9f5d7
+#define base01 #ebdbb2
+#define base02 #d5c4a1
+#define base03 #bdae93
+#define base04 #665c54
+#define base05 #504945
+#define base06 #3c3836
+#define base07 #282828
+#define base08 #9d0006
+#define base09 #af3a03
+#define base0A #b57614
+#define base0B #79740e
+#define base0C #427b58
+#define base0D #076678
+#define base0E #8f3f71
+#define base0F #d65d0e
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-gruvbox-light-medium-256.Xresources
+++ b/xresources/base16-gruvbox-light-medium-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-gruvbox-light-medium-256.Xresources
+++ b/xresources/base16-gruvbox-light-medium-256.Xresources
@@ -1,0 +1,54 @@
+! Base16 Gruvbox light, medium
+! Scheme: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+
+#define base00 #fbf1c7
+#define base01 #ebdbb2
+#define base02 #d5c4a1
+#define base03 #bdae93
+#define base04 #665c54
+#define base05 #504945
+#define base06 #3c3836
+#define base07 #282828
+#define base08 #9d0006
+#define base09 #af3a03
+#define base0A #b57614
+#define base0B #79740e
+#define base0C #427b58
+#define base0D #076678
+#define base0E #8f3f71
+#define base0F #d65d0e
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
+*.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-gruvbox-light-medium.Xresources
+++ b/xresources/base16-gruvbox-light-medium.Xresources
@@ -1,0 +1,45 @@
+! Base16 Gruvbox light, medium
+! Scheme: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+
+#define base00 #fbf1c7
+#define base01 #ebdbb2
+#define base02 #d5c4a1
+#define base03 #bdae93
+#define base04 #665c54
+#define base05 #504945
+#define base06 #3c3836
+#define base07 #282828
+#define base08 #9d0006
+#define base09 #af3a03
+#define base0A #b57614
+#define base0B #79740e
+#define base0C #427b58
+#define base0D #076678
+#define base0E #8f3f71
+#define base0F #d65d0e
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-gruvbox-light-medium.Xresources
+++ b/xresources/base16-gruvbox-light-medium.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-gruvbox-light-soft-256.Xresources
+++ b/xresources/base16-gruvbox-light-soft-256.Xresources
@@ -1,25 +1,29 @@
-! Base16 IR Black
-! Scheme: Timothée Poisot (http://timotheepoisot.fr)
+! Base16 Gruvbox light, soft
+! Scheme: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 
-#define base00 #000000
-#define base01 #242422
-#define base02 #484844
-#define base03 #6c6c66
-#define base04 #918f88
-#define base05 #b5b3aa
-#define base06 #d9d7cc
-#define base07 #fdfbee
-#define base08 #ff6c60
-#define base09 #e9c062
-#define base0A #ffffb6
-#define base0B #a8ff60
-#define base0C #c6c5fe
-#define base0D #96cbfe
-#define base0E #ff73fd
-#define base0F #b18a3d
+#define base00 #f2e5bc
+#define base01 #ebdbb2
+#define base02 #d5c4a1
+#define base03 #bdae93
+#define base04 #665c54
+#define base05 #504945
+#define base06 #3c3836
+#define base07 #282828
+#define base08 #9d0006
+#define base09 #af3a03
+#define base0A #b57614
+#define base0B #79740e
+#define base0C #427b58
+#define base0D #076678
+#define base0E #8f3f71
+#define base0F #d65d0e
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-gruvbox-light-soft-256.Xresources
+++ b/xresources/base16-gruvbox-light-soft-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-gruvbox-light-soft.Xresources
+++ b/xresources/base16-gruvbox-light-soft.Xresources
@@ -1,0 +1,45 @@
+! Base16 Gruvbox light, soft
+! Scheme: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
+
+#define base00 #f2e5bc
+#define base01 #ebdbb2
+#define base02 #d5c4a1
+#define base03 #bdae93
+#define base04 #665c54
+#define base05 #504945
+#define base06 #3c3836
+#define base07 #282828
+#define base08 #9d0006
+#define base09 #af3a03
+#define base0A #b57614
+#define base0B #79740e
+#define base0C #427b58
+#define base0D #076678
+#define base0E #8f3f71
+#define base0F #d65d0e
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-gruvbox-light-soft.Xresources
+++ b/xresources/base16-gruvbox-light-soft.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-harmonic-dark-256.Xresources
+++ b/xresources/base16-harmonic-dark-256.Xresources
@@ -1,0 +1,54 @@
+! Base16 Harmonic16 Dark
+! Scheme: Jannik Siebert (https://github.com/janniks)
+
+#define base00 #0b1c2c
+#define base01 #223b54
+#define base02 #405c79
+#define base03 #627e99
+#define base04 #aabcce
+#define base05 #cbd6e2
+#define base06 #e5ebf1
+#define base07 #f7f9fb
+#define base08 #bf8b56
+#define base09 #bfbf56
+#define base0A #8bbf56
+#define base0B #56bf8b
+#define base0C #568bbf
+#define base0D #8b56bf
+#define base0E #bf568b
+#define base0F #bf5656
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
+*.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-harmonic-dark-256.Xresources
+++ b/xresources/base16-harmonic-dark-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-harmonic-dark.Xresources
+++ b/xresources/base16-harmonic-dark.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-harmonic-dark.Xresources
+++ b/xresources/base16-harmonic-dark.Xresources
@@ -1,14 +1,14 @@
-! Base16 Harmonic16 Light
+! Base16 Harmonic16 Dark
 ! Scheme: Jannik Siebert (https://github.com/janniks)
 
-#define base00 #f7f9fb
-#define base01 #e5ebf1
-#define base02 #cbd6e2
-#define base03 #aabcce
-#define base04 #627e99
-#define base05 #405c79
-#define base06 #223b54
-#define base07 #0b1c2c
+#define base00 #0b1c2c
+#define base01 #223b54
+#define base02 #405c79
+#define base03 #627e99
+#define base04 #aabcce
+#define base05 #cbd6e2
+#define base06 #e5ebf1
+#define base07 #f7f9fb
 #define base08 #bf8b56
 #define base09 #bfbf56
 #define base0A #8bbf56
@@ -19,7 +19,11 @@
 #define base0F #bf5656
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-harmonic-light-256.Xresources
+++ b/xresources/base16-harmonic-light-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-harmonic-light-256.Xresources
+++ b/xresources/base16-harmonic-light-256.Xresources
@@ -1,0 +1,54 @@
+! Base16 Harmonic16 Light
+! Scheme: Jannik Siebert (https://github.com/janniks)
+
+#define base00 #f7f9fb
+#define base01 #e5ebf1
+#define base02 #cbd6e2
+#define base03 #aabcce
+#define base04 #627e99
+#define base05 #405c79
+#define base06 #223b54
+#define base07 #0b1c2c
+#define base08 #bf8b56
+#define base09 #bfbf56
+#define base0A #8bbf56
+#define base0B #56bf8b
+#define base0C #568bbf
+#define base0D #8b56bf
+#define base0E #bf568b
+#define base0F #bf5656
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
+*.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-harmonic-light.Xresources
+++ b/xresources/base16-harmonic-light.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-harmonic-light.Xresources
+++ b/xresources/base16-harmonic-light.Xresources
@@ -1,14 +1,14 @@
-! Base16 Harmonic16 Dark
+! Base16 Harmonic16 Light
 ! Scheme: Jannik Siebert (https://github.com/janniks)
 
-#define base00 #0b1c2c
-#define base01 #223b54
-#define base02 #405c79
-#define base03 #627e99
-#define base04 #aabcce
-#define base05 #cbd6e2
-#define base06 #e5ebf1
-#define base07 #f7f9fb
+#define base00 #f7f9fb
+#define base01 #e5ebf1
+#define base02 #cbd6e2
+#define base03 #aabcce
+#define base04 #627e99
+#define base05 #405c79
+#define base06 #223b54
+#define base07 #0b1c2c
 #define base08 #bf8b56
 #define base09 #bfbf56
 #define base0A #8bbf56
@@ -19,7 +19,11 @@
 #define base0F #bf5656
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-hopscotch-256.Xresources
+++ b/xresources/base16-hopscotch-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-hopscotch-256.Xresources
+++ b/xresources/base16-hopscotch-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #b33508
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-hopscotch.Xresources
+++ b/xresources/base16-hopscotch.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-hopscotch.Xresources
+++ b/xresources/base16-hopscotch.Xresources
@@ -19,7 +19,11 @@
 #define base0F #b33508
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-irblack-256.Xresources
+++ b/xresources/base16-irblack-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-irblack-256.Xresources
+++ b/xresources/base16-irblack-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #b18a3d
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00
@@ -32,10 +36,19 @@
 *.color7:       base05
 
 *.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
 *.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-irblack.Xresources
+++ b/xresources/base16-irblack.Xresources
@@ -1,0 +1,45 @@
+! Base16 IR Black
+! Scheme: Timothée Poisot (http://timotheepoisot.fr)
+
+#define base00 #000000
+#define base01 #242422
+#define base02 #484844
+#define base03 #6c6c66
+#define base04 #918f88
+#define base05 #b5b3aa
+#define base06 #d9d7cc
+#define base07 #fdfbee
+#define base08 #ff6c60
+#define base09 #e9c062
+#define base0A #ffffb6
+#define base0B #a8ff60
+#define base0C #c6c5fe
+#define base0D #96cbfe
+#define base0E #ff73fd
+#define base0F #b18a3d
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-irblack.Xresources
+++ b/xresources/base16-irblack.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-isotope-256.Xresources
+++ b/xresources/base16-isotope-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #3300ff
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-isotope-256.Xresources
+++ b/xresources/base16-isotope-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-isotope.Xresources
+++ b/xresources/base16-isotope.Xresources
@@ -19,7 +19,11 @@
 #define base0F #3300ff
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-isotope.Xresources
+++ b/xresources/base16-isotope.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-macintosh-256.Xresources
+++ b/xresources/base16-macintosh-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-macintosh-256.Xresources
+++ b/xresources/base16-macintosh-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #90713a
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-macintosh.Xresources
+++ b/xresources/base16-macintosh.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-macintosh.Xresources
+++ b/xresources/base16-macintosh.Xresources
@@ -19,7 +19,11 @@
 #define base0F #90713a
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-marrakesh-256.Xresources
+++ b/xresources/base16-marrakesh-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-marrakesh-256.Xresources
+++ b/xresources/base16-marrakesh-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #b3588e
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-marrakesh.Xresources
+++ b/xresources/base16-marrakesh.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-marrakesh.Xresources
+++ b/xresources/base16-marrakesh.Xresources
@@ -19,7 +19,11 @@
 #define base0F #b3588e
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-materia-256.Xresources
+++ b/xresources/base16-materia-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #EC5F67
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-materia-256.Xresources
+++ b/xresources/base16-materia-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-materia.Xresources
+++ b/xresources/base16-materia.Xresources
@@ -19,7 +19,11 @@
 #define base0F #EC5F67
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-materia.Xresources
+++ b/xresources/base16-materia.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-mexico-light-256.Xresources
+++ b/xresources/base16-mexico-light-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-mexico-light-256.Xresources
+++ b/xresources/base16-mexico-light-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #a16946
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-mexico-light.Xresources
+++ b/xresources/base16-mexico-light.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-mexico-light.Xresources
+++ b/xresources/base16-mexico-light.Xresources
@@ -19,7 +19,11 @@
 #define base0F #a16946
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-mocha-256.Xresources
+++ b/xresources/base16-mocha-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-mocha-256.Xresources
+++ b/xresources/base16-mocha-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #bb9584
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-mocha.Xresources
+++ b/xresources/base16-mocha.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-mocha.Xresources
+++ b/xresources/base16-mocha.Xresources
@@ -19,7 +19,11 @@
 #define base0F #bb9584
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-monokai-256.Xresources
+++ b/xresources/base16-monokai-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-monokai-256.Xresources
+++ b/xresources/base16-monokai-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #cc6633
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-monokai.Xresources
+++ b/xresources/base16-monokai.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-monokai.Xresources
+++ b/xresources/base16-monokai.Xresources
@@ -19,7 +19,11 @@
 #define base0F #cc6633
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-ocean-256.Xresources
+++ b/xresources/base16-ocean-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-ocean-256.Xresources
+++ b/xresources/base16-ocean-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #ab7967
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-ocean.Xresources
+++ b/xresources/base16-ocean.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-ocean.Xresources
+++ b/xresources/base16-ocean.Xresources
@@ -19,7 +19,11 @@
 #define base0F #ab7967
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-oceanicnext-256.Xresources
+++ b/xresources/base16-oceanicnext-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #AB7967
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-oceanicnext-256.Xresources
+++ b/xresources/base16-oceanicnext-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-oceanicnext.Xresources
+++ b/xresources/base16-oceanicnext.Xresources
@@ -19,7 +19,11 @@
 #define base0F #AB7967
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-oceanicnext.Xresources
+++ b/xresources/base16-oceanicnext.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-onedark-256.Xresources
+++ b/xresources/base16-onedark-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #be5046
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-onedark-256.Xresources
+++ b/xresources/base16-onedark-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-onedark.Xresources
+++ b/xresources/base16-onedark.Xresources
@@ -19,7 +19,11 @@
 #define base0F #be5046
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-onedark.Xresources
+++ b/xresources/base16-onedark.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-paraiso-256.Xresources
+++ b/xresources/base16-paraiso-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-paraiso-256.Xresources
+++ b/xresources/base16-paraiso-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #e96ba8
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-paraiso.Xresources
+++ b/xresources/base16-paraiso.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-paraiso.Xresources
+++ b/xresources/base16-paraiso.Xresources
@@ -19,7 +19,11 @@
 #define base0F #e96ba8
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-phd-256.Xresources
+++ b/xresources/base16-phd-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-phd-256.Xresources
+++ b/xresources/base16-phd-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #b08060
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-phd.Xresources
+++ b/xresources/base16-phd.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-phd.Xresources
+++ b/xresources/base16-phd.Xresources
@@ -19,7 +19,11 @@
 #define base0F #b08060
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-pico-256.Xresources
+++ b/xresources/base16-pico-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #ffccaa
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-pico-256.Xresources
+++ b/xresources/base16-pico-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-pico.Xresources
+++ b/xresources/base16-pico.Xresources
@@ -19,7 +19,11 @@
 #define base0F #ffccaa
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-pico.Xresources
+++ b/xresources/base16-pico.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-pop-256.Xresources
+++ b/xresources/base16-pop-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #7a2d00
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-pop-256.Xresources
+++ b/xresources/base16-pop-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-pop.Xresources
+++ b/xresources/base16-pop.Xresources
@@ -19,7 +19,11 @@
 #define base0F #7a2d00
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-pop.Xresources
+++ b/xresources/base16-pop.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-railscasts-256.Xresources
+++ b/xresources/base16-railscasts-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #bc9458
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-railscasts-256.Xresources
+++ b/xresources/base16-railscasts-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-railscasts.Xresources
+++ b/xresources/base16-railscasts.Xresources
@@ -19,7 +19,11 @@
 #define base0F #bc9458
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-railscasts.Xresources
+++ b/xresources/base16-railscasts.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-seti-256.Xresources
+++ b/xresources/base16-seti-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #8a553f
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00
@@ -32,10 +36,19 @@
 *.color7:       base05
 
 *.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
 *.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-seti-256.Xresources
+++ b/xresources/base16-seti-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-seti.Xresources
+++ b/xresources/base16-seti.Xresources
@@ -1,25 +1,29 @@
-! Base16 London Tube
-! Scheme: Jan T. Sott
+! Base16 Seti UI
+! Scheme: 
 
-#define base00 #231f20
-#define base01 #1c3f95
-#define base02 #5a5758
-#define base03 #737171
-#define base04 #959ca1
-#define base05 #d9d8d8
-#define base06 #e7e7e8
+#define base00 #151718
+#define base01 #8ec43d
+#define base02 #3B758C
+#define base03 #41535B
+#define base04 #43a5d5
+#define base05 #d6d6d6
+#define base06 #eeeeee
 #define base07 #ffffff
-#define base08 #ee2e24
-#define base09 #f386a1
-#define base0A #ffd204
-#define base0B #00853e
-#define base0C #85cebc
-#define base0D #009ddc
-#define base0E #98005d
-#define base0F #b06110
+#define base08 #Cd3f45
+#define base09 #db7b55
+#define base0A #e6cd69
+#define base0B #9fca56
+#define base0C #55dbbe
+#define base0D #55b5db
+#define base0E #a074c4
+#define base0F #8a553f
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-seti.Xresources
+++ b/xresources/base16-seti.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-shapeshifter-256.Xresources
+++ b/xresources/base16-shapeshifter-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-shapeshifter-256.Xresources
+++ b/xresources/base16-shapeshifter-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #69542d
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-shapeshifter.Xresources
+++ b/xresources/base16-shapeshifter.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-shapeshifter.Xresources
+++ b/xresources/base16-shapeshifter.Xresources
@@ -19,7 +19,11 @@
 #define base0F #69542d
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-solarflare-256.Xresources
+++ b/xresources/base16-solarflare-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-solarflare-256.Xresources
+++ b/xresources/base16-solarflare-256.Xresources
@@ -1,0 +1,54 @@
+! Base16 Solar Flare
+! Scheme: Chuck Harmston (https://chuck.harmston.ch)
+
+#define base00 #18262F
+#define base01 #222E38
+#define base02 #586875
+#define base03 #667581
+#define base04 #85939E
+#define base05 #A6AFB8
+#define base06 #E8E9ED
+#define base07 #F5F7FA
+#define base08 #EF5253
+#define base09 #E66B2B
+#define base0A #E4B51C
+#define base0B #7CC844
+#define base0C #52CBB0
+#define base0D #33B5E1
+#define base0E #A363D5
+#define base0F #D73C9A
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
+*.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-solarflare.Xresources
+++ b/xresources/base16-solarflare.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-solarflare.Xresources
+++ b/xresources/base16-solarflare.Xresources
@@ -19,7 +19,11 @@
 #define base0F #D73C9A
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-solarized-dark-256.Xresources
+++ b/xresources/base16-solarized-dark-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-solarized-dark-256.Xresources
+++ b/xresources/base16-solarized-dark-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #d33682
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-solarized-dark.Xresources
+++ b/xresources/base16-solarized-dark.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-solarized-dark.Xresources
+++ b/xresources/base16-solarized-dark.Xresources
@@ -19,7 +19,11 @@
 #define base0F #d33682
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-solarized-light-256.Xresources
+++ b/xresources/base16-solarized-light-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-solarized-light-256.Xresources
+++ b/xresources/base16-solarized-light-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #d33682
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-solarized-light.Xresources
+++ b/xresources/base16-solarized-light.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-solarized-light.Xresources
+++ b/xresources/base16-solarized-light.Xresources
@@ -19,7 +19,11 @@
 #define base0F #d33682
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-spacemacs-256.Xresources
+++ b/xresources/base16-spacemacs-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-spacemacs-256.Xresources
+++ b/xresources/base16-spacemacs-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #b03060
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-spacemacs.Xresources
+++ b/xresources/base16-spacemacs.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-spacemacs.Xresources
+++ b/xresources/base16-spacemacs.Xresources
@@ -19,7 +19,11 @@
 #define base0F #b03060
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-summerfruit-dark-256.Xresources
+++ b/xresources/base16-summerfruit-dark-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #CC6633
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-summerfruit-dark-256.Xresources
+++ b/xresources/base16-summerfruit-dark-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-summerfruit-dark.Xresources
+++ b/xresources/base16-summerfruit-dark.Xresources
@@ -19,7 +19,11 @@
 #define base0F #CC6633
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-summerfruit-dark.Xresources
+++ b/xresources/base16-summerfruit-dark.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-summerfruit-light-256.Xresources
+++ b/xresources/base16-summerfruit-light-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #CC6633
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-summerfruit-light-256.Xresources
+++ b/xresources/base16-summerfruit-light-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-summerfruit-light.Xresources
+++ b/xresources/base16-summerfruit-light.Xresources
@@ -19,7 +19,11 @@
 #define base0F #CC6633
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-summerfruit-light.Xresources
+++ b/xresources/base16-summerfruit-light.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-tomorrow-256.Xresources
+++ b/xresources/base16-tomorrow-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-tomorrow-256.Xresources
+++ b/xresources/base16-tomorrow-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #a3685a
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-tomorrow-night-256.Xresources
+++ b/xresources/base16-tomorrow-night-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-tomorrow-night-256.Xresources
+++ b/xresources/base16-tomorrow-night-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #a3685a
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-tomorrow-night.Xresources
+++ b/xresources/base16-tomorrow-night.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-tomorrow-night.Xresources
+++ b/xresources/base16-tomorrow-night.Xresources
@@ -19,7 +19,11 @@
 #define base0F #a3685a
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-tomorrow.Xresources
+++ b/xresources/base16-tomorrow.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-tomorrow.Xresources
+++ b/xresources/base16-tomorrow.Xresources
@@ -19,7 +19,11 @@
 #define base0F #a3685a
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-tube-256.Xresources
+++ b/xresources/base16-tube-256.Xresources
@@ -1,0 +1,54 @@
+! Base16 London Tube
+! Scheme: Jan T. Sott
+
+#define base00 #231f20
+#define base01 #1c3f95
+#define base02 #5a5758
+#define base03 #737171
+#define base04 #959ca1
+#define base05 #d9d8d8
+#define base06 #e7e7e8
+#define base07 #ffffff
+#define base08 #ee2e24
+#define base09 #f386a1
+#define base0A #ffd204
+#define base0B #00853e
+#define base0C #85cebc
+#define base0D #009ddc
+#define base0E #98005d
+#define base0F #b06110
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
+*.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-tube-256.Xresources
+++ b/xresources/base16-tube-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-tube.Xresources
+++ b/xresources/base16-tube.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-tube.Xresources
+++ b/xresources/base16-tube.Xresources
@@ -1,0 +1,45 @@
+! Base16 London Tube
+! Scheme: Jan T. Sott
+
+#define base00 #231f20
+#define base01 #1c3f95
+#define base02 #5a5758
+#define base03 #737171
+#define base04 #959ca1
+#define base05 #d9d8d8
+#define base06 #e7e7e8
+#define base07 #ffffff
+#define base08 #ee2e24
+#define base09 #f386a1
+#define base0A #ffd204
+#define base0B #00853e
+#define base0C #85cebc
+#define base0D #009ddc
+#define base0E #98005d
+#define base0F #b06110
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-twilight-256.Xresources
+++ b/xresources/base16-twilight-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-twilight-256.Xresources
+++ b/xresources/base16-twilight-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #9b703f
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-twilight.Xresources
+++ b/xresources/base16-twilight.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-twilight.Xresources
+++ b/xresources/base16-twilight.Xresources
@@ -19,7 +19,11 @@
 #define base0F #9b703f
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-unikitty-dark-256.Xresources
+++ b/xresources/base16-unikitty-dark-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #c720ca
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-unikitty-dark-256.Xresources
+++ b/xresources/base16-unikitty-dark-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-unikitty-dark.Xresources
+++ b/xresources/base16-unikitty-dark.Xresources
@@ -19,7 +19,11 @@
 #define base0F #c720ca
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-unikitty-dark.Xresources
+++ b/xresources/base16-unikitty-dark.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-unikitty-light-256.Xresources
+++ b/xresources/base16-unikitty-light-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-unikitty-light-256.Xresources
+++ b/xresources/base16-unikitty-light-256.Xresources
@@ -19,7 +19,11 @@
 #define base0F #e013d0
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-unikitty-light.Xresources
+++ b/xresources/base16-unikitty-light.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-unikitty-light.Xresources
+++ b/xresources/base16-unikitty-light.Xresources
@@ -19,7 +19,11 @@
 #define base0F #e013d0
 
 *.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
 *.background:   base00
+#endif
 *.cursorColor:  base05
 
 *.color0:       base00

--- a/xresources/base16-woodland-256.Xresources
+++ b/xresources/base16-woodland-256.Xresources
@@ -1,0 +1,54 @@
+! Base16 Woodland
+! Scheme: Jay Cornwall (https://jcornwall.com)
+
+#define base00 #231e18
+#define base01 #302b25
+#define base02 #48413a
+#define base03 #9d8b70
+#define base04 #b4a490
+#define base05 #cabcb1
+#define base06 #d7c8bc
+#define base07 #e4d4c8
+#define base08 #d35c5c
+#define base09 #ca7f32
+#define base0A #e0ac16
+#define base0B #b7ba53
+#define base0C #6eb958
+#define base0D #88a4d3
+#define base0E #bb90e2
+#define base0F #b49368
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base08
+*.color10:      base0B
+*.color11:      base0A
+*.color12:      base0D
+*.color13:      base0E
+*.color14:      base0C
+*.color15:      base07
+
+! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
+! use 'shell' template to set these if necessary
+*.color16:      base09
+*.color17:      base0F
+*.color18:      base01
+*.color19:      base02
+*.color20:      base04
+*.color21:      base06

--- a/xresources/base16-woodland-256.Xresources
+++ b/xresources/base16-woodland-256.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif

--- a/xresources/base16-woodland.Xresources
+++ b/xresources/base16-woodland.Xresources
@@ -1,0 +1,45 @@
+! Base16 Woodland
+! Scheme: Jay Cornwall (https://jcornwall.com)
+
+#define base00 #231e18
+#define base01 #302b25
+#define base02 #48413a
+#define base03 #9d8b70
+#define base04 #b4a490
+#define base05 #cabcb1
+#define base06 #d7c8bc
+#define base07 #e4d4c8
+#define base08 #d35c5c
+#define base09 #ca7f32
+#define base0A #e0ac16
+#define base0B #b7ba53
+#define base0C #6eb958
+#define base0D #88a4d3
+#define base0E #bb90e2
+#define base0F #b49368
+
+*.foreground:   base05
+#ifdef background_opacity
+*.background:   [background_opacity] base00
+#else
+*.background:   base00
+#endif
+*.cursorColor:  base05
+
+*.color0:       base00
+*.color1:       base08
+*.color2:       base0B
+*.color3:       base0A
+*.color4:       base0D
+*.color5:       base0E
+*.color6:       base0C
+*.color7:       base05
+
+*.color8:       base03
+*.color9:       base09
+*.color10:      base01
+*.color11:      base02
+*.color12:      base04
+*.color13:      base06
+*.color14:      base0F
+*.color15:      base07

--- a/xresources/base16-woodland.Xresources
+++ b/xresources/base16-woodland.Xresources
@@ -20,7 +20,7 @@
 
 *.foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity] base00
+*.background:   [background_opacity]base00
 #else
 *.background:   base00
 #endif


### PR DESCRIPTION
Lets the user specify an opacity for the background color. The desired opacity should be specified before the included *.Xresources file. For example:

```
...
#define background_opacity 95
#include ".config/base16-xresources/xresources/base16-onedark-256.Xresources"
...
```

If `background_opacity` is not defined, it falls back to no opacity specified at all in the .Xresources file.