### PR TITLE
fixed invalid wildcard usage, rebuilt

### DIFF
--- a/templates/default-256.mustache
+++ b/templates/default-256.mustache
@@ -18,37 +18,37 @@
 #define base0E #{{base0E-hex}}
 #define base0F #{{base0F-hex}}
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -18,28 +18,28 @@
 #define base0E #{{base0E-hex}}
 #define base0F #{{base0F-hex}}
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-3024-256.Xresources
+++ b/xresources/base16-3024-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #a16a94
 #define base0F #cdab53
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-3024.Xresources
+++ b/xresources/base16-3024.Xresources
@@ -18,28 +18,28 @@
 #define base0E #a16a94
 #define base0F #cdab53
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-apathy-256.Xresources
+++ b/xresources/base16-apathy-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #4c963e
 #define base0F #3e965b
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-apathy.Xresources
+++ b/xresources/base16-apathy.Xresources
@@ -18,28 +18,28 @@
 #define base0E #4c963e
 #define base0F #3e965b
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-ashes-256.Xresources
+++ b/xresources/base16-ashes-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #c795ae
 #define base0F #c79595
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-ashes.Xresources
+++ b/xresources/base16-ashes.Xresources
@@ -18,28 +18,28 @@
 #define base0E #c795ae
 #define base0F #c79595
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-cave-256.Xresources
+++ b/xresources/base16-atelier-cave-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #955ae7
 #define base0F #bf40bf
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-cave-light-256.Xresources
+++ b/xresources/base16-atelier-cave-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #955ae7
 #define base0F #bf40bf
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-cave-light.Xresources
+++ b/xresources/base16-atelier-cave-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #955ae7
 #define base0F #bf40bf
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-cave.Xresources
+++ b/xresources/base16-atelier-cave.Xresources
@@ -18,28 +18,28 @@
 #define base0E #955ae7
 #define base0F #bf40bf
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-dune-256.Xresources
+++ b/xresources/base16-atelier-dune-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #b854d4
 #define base0F #d43552
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-dune-light-256.Xresources
+++ b/xresources/base16-atelier-dune-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #b854d4
 #define base0F #d43552
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-dune-light.Xresources
+++ b/xresources/base16-atelier-dune-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #b854d4
 #define base0F #d43552
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-dune.Xresources
+++ b/xresources/base16-atelier-dune.Xresources
@@ -18,28 +18,28 @@
 #define base0E #b854d4
 #define base0F #d43552
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-estuary-256.Xresources
+++ b/xresources/base16-atelier-estuary-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #5f9182
 #define base0F #9d6c7c
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-estuary-light-256.Xresources
+++ b/xresources/base16-atelier-estuary-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #5f9182
 #define base0F #9d6c7c
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-estuary-light.Xresources
+++ b/xresources/base16-atelier-estuary-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #5f9182
 #define base0F #9d6c7c
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-estuary.Xresources
+++ b/xresources/base16-atelier-estuary.Xresources
@@ -18,28 +18,28 @@
 #define base0E #5f9182
 #define base0F #9d6c7c
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-forest-256.Xresources
+++ b/xresources/base16-atelier-forest-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #6666ea
 #define base0F #c33ff3
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-forest-light-256.Xresources
+++ b/xresources/base16-atelier-forest-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #6666ea
 #define base0F #c33ff3
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-forest-light.Xresources
+++ b/xresources/base16-atelier-forest-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #6666ea
 #define base0F #c33ff3
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-forest.Xresources
+++ b/xresources/base16-atelier-forest.Xresources
@@ -18,28 +18,28 @@
 #define base0E #6666ea
 #define base0F #c33ff3
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-heath-256.Xresources
+++ b/xresources/base16-atelier-heath-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #7b59c0
 #define base0F #cc33cc
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-heath-light-256.Xresources
+++ b/xresources/base16-atelier-heath-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #7b59c0
 #define base0F #cc33cc
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-heath-light.Xresources
+++ b/xresources/base16-atelier-heath-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #7b59c0
 #define base0F #cc33cc
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-heath.Xresources
+++ b/xresources/base16-atelier-heath.Xresources
@@ -18,28 +18,28 @@
 #define base0E #7b59c0
 #define base0F #cc33cc
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-lakeside-256.Xresources
+++ b/xresources/base16-atelier-lakeside-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #6b6bb8
 #define base0F #b72dd2
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-lakeside-light-256.Xresources
+++ b/xresources/base16-atelier-lakeside-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #6b6bb8
 #define base0F #b72dd2
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-lakeside-light.Xresources
+++ b/xresources/base16-atelier-lakeside-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #6b6bb8
 #define base0F #b72dd2
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-lakeside.Xresources
+++ b/xresources/base16-atelier-lakeside.Xresources
@@ -18,28 +18,28 @@
 #define base0E #6b6bb8
 #define base0F #b72dd2
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-plateau-256.Xresources
+++ b/xresources/base16-atelier-plateau-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #8464c4
 #define base0F #bd5187
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-plateau-light-256.Xresources
+++ b/xresources/base16-atelier-plateau-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #8464c4
 #define base0F #bd5187
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-plateau-light.Xresources
+++ b/xresources/base16-atelier-plateau-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #8464c4
 #define base0F #bd5187
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-plateau.Xresources
+++ b/xresources/base16-atelier-plateau.Xresources
@@ -18,28 +18,28 @@
 #define base0E #8464c4
 #define base0F #bd5187
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-savanna-256.Xresources
+++ b/xresources/base16-atelier-savanna-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #55859b
 #define base0F #867469
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-savanna-light-256.Xresources
+++ b/xresources/base16-atelier-savanna-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #55859b
 #define base0F #867469
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-savanna-light.Xresources
+++ b/xresources/base16-atelier-savanna-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #55859b
 #define base0F #867469
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-savanna.Xresources
+++ b/xresources/base16-atelier-savanna.Xresources
@@ -18,28 +18,28 @@
 #define base0E #55859b
 #define base0F #867469
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-seaside-256.Xresources
+++ b/xresources/base16-atelier-seaside-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #ad2bee
 #define base0F #e619c3
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-seaside-light-256.Xresources
+++ b/xresources/base16-atelier-seaside-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #ad2bee
 #define base0F #e619c3
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-seaside-light.Xresources
+++ b/xresources/base16-atelier-seaside-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #ad2bee
 #define base0F #e619c3
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-seaside.Xresources
+++ b/xresources/base16-atelier-seaside.Xresources
@@ -18,28 +18,28 @@
 #define base0E #ad2bee
 #define base0F #e619c3
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-sulphurpool-256.Xresources
+++ b/xresources/base16-atelier-sulphurpool-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #6679cc
 #define base0F #9c637a
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-sulphurpool-light-256.Xresources
+++ b/xresources/base16-atelier-sulphurpool-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #6679cc
 #define base0F #9c637a
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-atelier-sulphurpool-light.Xresources
+++ b/xresources/base16-atelier-sulphurpool-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #6679cc
 #define base0F #9c637a
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-atelier-sulphurpool.Xresources
+++ b/xresources/base16-atelier-sulphurpool.Xresources
@@ -18,28 +18,28 @@
 #define base0E #6679cc
 #define base0F #9c637a
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-bespin-256.Xresources
+++ b/xresources/base16-bespin-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #9b859d
 #define base0F #937121
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-bespin.Xresources
+++ b/xresources/base16-bespin.Xresources
@@ -18,28 +18,28 @@
 #define base0E #9b859d
 #define base0F #937121
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-brewer-256.Xresources
+++ b/xresources/base16-brewer-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #756bb1
 #define base0F #b15928
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-brewer.Xresources
+++ b/xresources/base16-brewer.Xresources
@@ -18,28 +18,28 @@
 #define base0E #756bb1
 #define base0F #b15928
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-bright-256.Xresources
+++ b/xresources/base16-bright-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #d381c3
 #define base0F #be643c
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-bright.Xresources
+++ b/xresources/base16-bright.Xresources
@@ -18,28 +18,28 @@
 #define base0E #d381c3
 #define base0F #be643c
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-brushtrees-256.Xresources
+++ b/xresources/base16-brushtrees-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #b386b2
 #define base0F #b39f9f
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-brushtrees-dark-256.Xresources
+++ b/xresources/base16-brushtrees-dark-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #b386b2
 #define base0F #b39f9f
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-brushtrees-dark.Xresources
+++ b/xresources/base16-brushtrees-dark.Xresources
@@ -18,28 +18,28 @@
 #define base0E #b386b2
 #define base0F #b39f9f
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-brushtrees.Xresources
+++ b/xresources/base16-brushtrees.Xresources
@@ -18,28 +18,28 @@
 #define base0E #b386b2
 #define base0F #b39f9f
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-chalk-256.Xresources
+++ b/xresources/base16-chalk-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #e1a3ee
 #define base0F #deaf8f
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-chalk.Xresources
+++ b/xresources/base16-chalk.Xresources
@@ -18,28 +18,28 @@
 #define base0E #e1a3ee
 #define base0F #deaf8f
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-circus-256.Xresources
+++ b/xresources/base16-circus-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #b888e2
 #define base0F #b888e2
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-circus.Xresources
+++ b/xresources/base16-circus.Xresources
@@ -18,28 +18,28 @@
 #define base0E #b888e2
 #define base0F #b888e2
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-classic-dark-256.Xresources
+++ b/xresources/base16-classic-dark-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #aa759f
 #define base0F #8f5536
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-classic-dark.Xresources
+++ b/xresources/base16-classic-dark.Xresources
@@ -18,28 +18,28 @@
 #define base0E #aa759f
 #define base0F #8f5536
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-classic-light-256.Xresources
+++ b/xresources/base16-classic-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #aa759f
 #define base0F #8f5536
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-classic-light.Xresources
+++ b/xresources/base16-classic-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #aa759f
 #define base0F #8f5536
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-codeschool-256.Xresources
+++ b/xresources/base16-codeschool-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #c59820
 #define base0F #c98344
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-codeschool.Xresources
+++ b/xresources/base16-codeschool.Xresources
@@ -18,28 +18,28 @@
 #define base0E #c59820
 #define base0F #c98344
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-cupcake-256.Xresources
+++ b/xresources/base16-cupcake-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #bb99b4
 #define base0F #baa58c
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-cupcake.Xresources
+++ b/xresources/base16-cupcake.Xresources
@@ -18,28 +18,28 @@
 #define base0E #bb99b4
 #define base0F #baa58c
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-cupertino-256.Xresources
+++ b/xresources/base16-cupertino-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #a90d91
 #define base0F #826b28
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-cupertino.Xresources
+++ b/xresources/base16-cupertino.Xresources
@@ -18,28 +18,28 @@
 #define base0E #a90d91
 #define base0F #826b28
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-darktooth-256.Xresources
+++ b/xresources/base16-darktooth-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #8f4673
 #define base0F #a87322
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-darktooth.Xresources
+++ b/xresources/base16-darktooth.Xresources
@@ -18,28 +18,28 @@
 #define base0E #8f4673
 #define base0F #a87322
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-default-dark-256.Xresources
+++ b/xresources/base16-default-dark-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #ba8baf
 #define base0F #a16946
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-default-dark.Xresources
+++ b/xresources/base16-default-dark.Xresources
@@ -18,28 +18,28 @@
 #define base0E #ba8baf
 #define base0F #a16946
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-default-light-256.Xresources
+++ b/xresources/base16-default-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #ba8baf
 #define base0F #a16946
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-default-light.Xresources
+++ b/xresources/base16-default-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #ba8baf
 #define base0F #a16946
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-dracula-256.Xresources
+++ b/xresources/base16-dracula-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #b45bcf
 #define base0F #00f769
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-dracula.Xresources
+++ b/xresources/base16-dracula.Xresources
@@ -18,28 +18,28 @@
 #define base0E #b45bcf
 #define base0F #00f769
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-eighties-256.Xresources
+++ b/xresources/base16-eighties-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #cc99cc
 #define base0F #d27b53
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-eighties.Xresources
+++ b/xresources/base16-eighties.Xresources
@@ -18,28 +18,28 @@
 #define base0E #cc99cc
 #define base0F #d27b53
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-embers-256.Xresources
+++ b/xresources/base16-embers-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #82576d
 #define base0F #825757
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-embers.Xresources
+++ b/xresources/base16-embers.Xresources
@@ -18,28 +18,28 @@
 #define base0E #82576d
 #define base0F #825757
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-flat-256.Xresources
+++ b/xresources/base16-flat-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #9b59b6
 #define base0F #be643c
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-flat.Xresources
+++ b/xresources/base16-flat.Xresources
@@ -18,28 +18,28 @@
 #define base0E #9b59b6
 #define base0F #be643c
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-github-256.Xresources
+++ b/xresources/base16-github-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #a71d5d
 #define base0F #333333
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-github.Xresources
+++ b/xresources/base16-github.Xresources
@@ -18,28 +18,28 @@
 #define base0E #a71d5d
 #define base0F #333333
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-google-dark-256.Xresources
+++ b/xresources/base16-google-dark-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #a36ac7
 #define base0F #3971ed
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-google-dark.Xresources
+++ b/xresources/base16-google-dark.Xresources
@@ -18,28 +18,28 @@
 #define base0E #a36ac7
 #define base0F #3971ed
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-google-light-256.Xresources
+++ b/xresources/base16-google-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #a36ac7
 #define base0F #3971ed
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-google-light.Xresources
+++ b/xresources/base16-google-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #a36ac7
 #define base0F #3971ed
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-grayscale-dark-256.Xresources
+++ b/xresources/base16-grayscale-dark-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #747474
 #define base0F #5e5e5e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-grayscale-dark.Xresources
+++ b/xresources/base16-grayscale-dark.Xresources
@@ -18,28 +18,28 @@
 #define base0E #747474
 #define base0F #5e5e5e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-grayscale-light-256.Xresources
+++ b/xresources/base16-grayscale-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #747474
 #define base0F #5e5e5e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-grayscale-light.Xresources
+++ b/xresources/base16-grayscale-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #747474
 #define base0F #5e5e5e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-greenscreen-256.Xresources
+++ b/xresources/base16-greenscreen-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #00bb00
 #define base0F #005500
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-greenscreen.Xresources
+++ b/xresources/base16-greenscreen.Xresources
@@ -18,28 +18,28 @@
 #define base0E #00bb00
 #define base0F #005500
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-gruvbox-dark-hard-256.Xresources
+++ b/xresources/base16-gruvbox-dark-hard-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #d3869b
 #define base0F #d65d0e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-gruvbox-dark-hard.Xresources
+++ b/xresources/base16-gruvbox-dark-hard.Xresources
@@ -18,28 +18,28 @@
 #define base0E #d3869b
 #define base0F #d65d0e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-gruvbox-dark-medium-256.Xresources
+++ b/xresources/base16-gruvbox-dark-medium-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #d3869b
 #define base0F #d65d0e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-gruvbox-dark-medium.Xresources
+++ b/xresources/base16-gruvbox-dark-medium.Xresources
@@ -18,28 +18,28 @@
 #define base0E #d3869b
 #define base0F #d65d0e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-gruvbox-dark-pale-256.Xresources
+++ b/xresources/base16-gruvbox-dark-pale-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #d485ad
 #define base0F #d65d0e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-gruvbox-dark-pale.Xresources
+++ b/xresources/base16-gruvbox-dark-pale.Xresources
@@ -18,28 +18,28 @@
 #define base0E #d485ad
 #define base0F #d65d0e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-gruvbox-dark-soft-256.Xresources
+++ b/xresources/base16-gruvbox-dark-soft-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #d3869b
 #define base0F #d65d0e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-gruvbox-dark-soft.Xresources
+++ b/xresources/base16-gruvbox-dark-soft.Xresources
@@ -18,28 +18,28 @@
 #define base0E #d3869b
 #define base0F #d65d0e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-gruvbox-light-hard-256.Xresources
+++ b/xresources/base16-gruvbox-light-hard-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #8f3f71
 #define base0F #d65d0e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-gruvbox-light-hard.Xresources
+++ b/xresources/base16-gruvbox-light-hard.Xresources
@@ -18,28 +18,28 @@
 #define base0E #8f3f71
 #define base0F #d65d0e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-gruvbox-light-medium-256.Xresources
+++ b/xresources/base16-gruvbox-light-medium-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #8f3f71
 #define base0F #d65d0e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-gruvbox-light-medium.Xresources
+++ b/xresources/base16-gruvbox-light-medium.Xresources
@@ -18,28 +18,28 @@
 #define base0E #8f3f71
 #define base0F #d65d0e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-gruvbox-light-soft-256.Xresources
+++ b/xresources/base16-gruvbox-light-soft-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #8f3f71
 #define base0F #d65d0e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-gruvbox-light-soft.Xresources
+++ b/xresources/base16-gruvbox-light-soft.Xresources
@@ -18,28 +18,28 @@
 #define base0E #8f3f71
 #define base0F #d65d0e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-harmonic-dark-256.Xresources
+++ b/xresources/base16-harmonic-dark-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #bf568b
 #define base0F #bf5656
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-harmonic-dark.Xresources
+++ b/xresources/base16-harmonic-dark.Xresources
@@ -18,28 +18,28 @@
 #define base0E #bf568b
 #define base0F #bf5656
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-harmonic-light-256.Xresources
+++ b/xresources/base16-harmonic-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #bf568b
 #define base0F #bf5656
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-harmonic-light.Xresources
+++ b/xresources/base16-harmonic-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #bf568b
 #define base0F #bf5656
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-hopscotch-256.Xresources
+++ b/xresources/base16-hopscotch-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #c85e7c
 #define base0F #b33508
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-hopscotch.Xresources
+++ b/xresources/base16-hopscotch.Xresources
@@ -18,28 +18,28 @@
 #define base0E #c85e7c
 #define base0F #b33508
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-irblack-256.Xresources
+++ b/xresources/base16-irblack-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #ff73fd
 #define base0F #b18a3d
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-irblack.Xresources
+++ b/xresources/base16-irblack.Xresources
@@ -18,28 +18,28 @@
 #define base0E #ff73fd
 #define base0F #b18a3d
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-isotope-256.Xresources
+++ b/xresources/base16-isotope-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #cc00ff
 #define base0F #3300ff
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-isotope.Xresources
+++ b/xresources/base16-isotope.Xresources
@@ -18,28 +18,28 @@
 #define base0E #cc00ff
 #define base0F #3300ff
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-macintosh-256.Xresources
+++ b/xresources/base16-macintosh-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #4700a5
 #define base0F #90713a
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-macintosh.Xresources
+++ b/xresources/base16-macintosh.Xresources
@@ -18,28 +18,28 @@
 #define base0E #4700a5
 #define base0F #90713a
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-marrakesh-256.Xresources
+++ b/xresources/base16-marrakesh-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #8868b3
 #define base0F #b3588e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-marrakesh.Xresources
+++ b/xresources/base16-marrakesh.Xresources
@@ -18,28 +18,28 @@
 #define base0E #8868b3
 #define base0F #b3588e
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-materia-256.Xresources
+++ b/xresources/base16-materia-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #82aaff
 #define base0F #ec5f67
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-materia.Xresources
+++ b/xresources/base16-materia.Xresources
@@ -18,28 +18,28 @@
 #define base0E #82aaff
 #define base0F #ec5f67
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-material-256.Xresources
+++ b/xresources/base16-material-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #c792ea
 #define base0F #ff5370
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-material-darker-256.Xresources
+++ b/xresources/base16-material-darker-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #c792ea
 #define base0F #ff5370
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-material-darker.Xresources
+++ b/xresources/base16-material-darker.Xresources
@@ -18,28 +18,28 @@
 #define base0E #c792ea
 #define base0F #ff5370
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-material-lighter-256.Xresources
+++ b/xresources/base16-material-lighter-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #7c4dff
 #define base0F #e53935
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-material-lighter.Xresources
+++ b/xresources/base16-material-lighter.Xresources
@@ -18,28 +18,28 @@
 #define base0E #7c4dff
 #define base0F #e53935
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-material-palenight-256.Xresources
+++ b/xresources/base16-material-palenight-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #c792ea
 #define base0F #ff5370
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-material-palenight.Xresources
+++ b/xresources/base16-material-palenight.Xresources
@@ -18,28 +18,28 @@
 #define base0E #c792ea
 #define base0F #ff5370
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-material.Xresources
+++ b/xresources/base16-material.Xresources
@@ -18,28 +18,28 @@
 #define base0E #c792ea
 #define base0F #ff5370
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-mellow-purple-256.Xresources
+++ b/xresources/base16-mellow-purple-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #8991bb
 #define base0F #4d6fff
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-mellow-purple.Xresources
+++ b/xresources/base16-mellow-purple.Xresources
@@ -18,28 +18,28 @@
 #define base0E #8991bb
 #define base0F #4d6fff
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-mexico-light-256.Xresources
+++ b/xresources/base16-mexico-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #96609e
 #define base0F #a16946
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-mexico-light.Xresources
+++ b/xresources/base16-mexico-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #96609e
 #define base0F #a16946
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-mocha-256.Xresources
+++ b/xresources/base16-mocha-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #a89bb9
 #define base0F #bb9584
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-mocha.Xresources
+++ b/xresources/base16-mocha.Xresources
@@ -18,28 +18,28 @@
 #define base0E #a89bb9
 #define base0F #bb9584
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-monokai-256.Xresources
+++ b/xresources/base16-monokai-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #ae81ff
 #define base0F #cc6633
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-monokai.Xresources
+++ b/xresources/base16-monokai.Xresources
@@ -18,28 +18,28 @@
 #define base0E #ae81ff
 #define base0F #cc6633
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-nord-256.Xresources
+++ b/xresources/base16-nord-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #a3be8c
 #define base0F #b48ead
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-nord.Xresources
+++ b/xresources/base16-nord.Xresources
@@ -18,28 +18,28 @@
 #define base0E #a3be8c
 #define base0F #b48ead
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-ocean-256.Xresources
+++ b/xresources/base16-ocean-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #b48ead
 #define base0F #ab7967
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-ocean.Xresources
+++ b/xresources/base16-ocean.Xresources
@@ -18,28 +18,28 @@
 #define base0E #b48ead
 #define base0F #ab7967
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-oceanicnext-256.Xresources
+++ b/xresources/base16-oceanicnext-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #c594c5
 #define base0F #ab7967
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-oceanicnext.Xresources
+++ b/xresources/base16-oceanicnext.Xresources
@@ -18,28 +18,28 @@
 #define base0E #c594c5
 #define base0F #ab7967
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-one-light-256.Xresources
+++ b/xresources/base16-one-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #a626a4
 #define base0F #986801
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-one-light.Xresources
+++ b/xresources/base16-one-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #a626a4
 #define base0F #986801
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-onedark-256.Xresources
+++ b/xresources/base16-onedark-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #c678dd
 #define base0F #be5046
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-onedark.Xresources
+++ b/xresources/base16-onedark.Xresources
@@ -18,28 +18,28 @@
 #define base0E #c678dd
 #define base0F #be5046
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-paraiso-256.Xresources
+++ b/xresources/base16-paraiso-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #815ba4
 #define base0F #e96ba8
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-paraiso.Xresources
+++ b/xresources/base16-paraiso.Xresources
@@ -18,28 +18,28 @@
 #define base0E #815ba4
 #define base0F #e96ba8
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-phd-256.Xresources
+++ b/xresources/base16-phd-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #9989cc
 #define base0F #b08060
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-phd.Xresources
+++ b/xresources/base16-phd.Xresources
@@ -18,28 +18,28 @@
 #define base0E #9989cc
 #define base0F #b08060
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-pico-256.Xresources
+++ b/xresources/base16-pico-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #ff77a8
 #define base0F #ffccaa
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-pico.Xresources
+++ b/xresources/base16-pico.Xresources
@@ -18,28 +18,28 @@
 #define base0E #ff77a8
 #define base0F #ffccaa
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-pop-256.Xresources
+++ b/xresources/base16-pop-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #b31e8d
 #define base0F #7a2d00
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-pop.Xresources
+++ b/xresources/base16-pop.Xresources
@@ -18,28 +18,28 @@
 #define base0E #b31e8d
 #define base0F #7a2d00
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-porple-256.Xresources
+++ b/xresources/base16-porple-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #b74989
 #define base0F #986841
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-porple.Xresources
+++ b/xresources/base16-porple.Xresources
@@ -18,28 +18,28 @@
 #define base0E #b74989
 #define base0F #986841
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-railscasts-256.Xresources
+++ b/xresources/base16-railscasts-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #b6b3eb
 #define base0F #bc9458
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-railscasts.Xresources
+++ b/xresources/base16-railscasts.Xresources
@@ -18,28 +18,28 @@
 #define base0E #b6b3eb
 #define base0F #bc9458
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-rebecca-256.Xresources
+++ b/xresources/base16-rebecca-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #7aa5ff
 #define base0F #ff79c6
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-rebecca.Xresources
+++ b/xresources/base16-rebecca.Xresources
@@ -18,28 +18,28 @@
 #define base0E #7aa5ff
 #define base0F #ff79c6
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-seti-256.Xresources
+++ b/xresources/base16-seti-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #a074c4
 #define base0F #8a553f
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-seti.Xresources
+++ b/xresources/base16-seti.Xresources
@@ -18,28 +18,28 @@
 #define base0E #a074c4
 #define base0F #8a553f
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-shapeshifter-256.Xresources
+++ b/xresources/base16-shapeshifter-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #f996e2
 #define base0F #69542d
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-shapeshifter.Xresources
+++ b/xresources/base16-shapeshifter.Xresources
@@ -18,28 +18,28 @@
 #define base0E #f996e2
 #define base0F #69542d
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-solarflare-256.Xresources
+++ b/xresources/base16-solarflare-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #a363d5
 #define base0F #d73c9a
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-solarflare.Xresources
+++ b/xresources/base16-solarflare.Xresources
@@ -18,28 +18,28 @@
 #define base0E #a363d5
 #define base0F #d73c9a
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-solarized-dark-256.Xresources
+++ b/xresources/base16-solarized-dark-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #6c71c4
 #define base0F #d33682
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-solarized-dark.Xresources
+++ b/xresources/base16-solarized-dark.Xresources
@@ -18,28 +18,28 @@
 #define base0E #6c71c4
 #define base0F #d33682
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-solarized-light-256.Xresources
+++ b/xresources/base16-solarized-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #6c71c4
 #define base0F #d33682
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-solarized-light.Xresources
+++ b/xresources/base16-solarized-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #6c71c4
 #define base0F #d33682
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-spacemacs-256.Xresources
+++ b/xresources/base16-spacemacs-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #a31db1
 #define base0F #b03060
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-spacemacs.Xresources
+++ b/xresources/base16-spacemacs.Xresources
@@ -18,28 +18,28 @@
 #define base0E #a31db1
 #define base0F #b03060
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-summerfruit-dark-256.Xresources
+++ b/xresources/base16-summerfruit-dark-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #ad00a1
 #define base0F #cc6633
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-summerfruit-dark.Xresources
+++ b/xresources/base16-summerfruit-dark.Xresources
@@ -18,28 +18,28 @@
 #define base0E #ad00a1
 #define base0F #cc6633
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-summerfruit-light-256.Xresources
+++ b/xresources/base16-summerfruit-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #ad00a1
 #define base0F #cc6633
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-summerfruit-light.Xresources
+++ b/xresources/base16-summerfruit-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #ad00a1
 #define base0F #cc6633
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-tomorrow-256.Xresources
+++ b/xresources/base16-tomorrow-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #8959a8
 #define base0F #a3685a
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-tomorrow-night-256.Xresources
+++ b/xresources/base16-tomorrow-night-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #b294bb
 #define base0F #a3685a
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-tomorrow-night.Xresources
+++ b/xresources/base16-tomorrow-night.Xresources
@@ -18,28 +18,28 @@
 #define base0E #b294bb
 #define base0F #a3685a
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-tomorrow.Xresources
+++ b/xresources/base16-tomorrow.Xresources
@@ -18,28 +18,28 @@
 #define base0E #8959a8
 #define base0F #a3685a
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-tube-256.Xresources
+++ b/xresources/base16-tube-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #98005d
 #define base0F #b06110
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-tube.Xresources
+++ b/xresources/base16-tube.Xresources
@@ -18,28 +18,28 @@
 #define base0E #98005d
 #define base0F #b06110
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-twilight-256.Xresources
+++ b/xresources/base16-twilight-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #9b859d
 #define base0F #9b703f
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-twilight.Xresources
+++ b/xresources/base16-twilight.Xresources
@@ -18,28 +18,28 @@
 #define base0E #9b859d
 #define base0F #9b703f
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-unikitty-dark-256.Xresources
+++ b/xresources/base16-unikitty-dark-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #bb60ea
 #define base0F #c720ca
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-unikitty-dark.Xresources
+++ b/xresources/base16-unikitty-dark.Xresources
@@ -18,28 +18,28 @@
 #define base0E #bb60ea
 #define base0F #c720ca
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-unikitty-light-256.Xresources
+++ b/xresources/base16-unikitty-light-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #aa17e6
 #define base0F #e013d0
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-unikitty-light.Xresources
+++ b/xresources/base16-unikitty-light.Xresources
@@ -18,28 +18,28 @@
 #define base0E #aa17e6
 #define base0F #e013d0
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-woodland-256.Xresources
+++ b/xresources/base16-woodland-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #bb90e2
 #define base0F #b49368
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-woodland.Xresources
+++ b/xresources/base16-woodland.Xresources
@@ -18,28 +18,28 @@
 #define base0E #bb90e2
 #define base0F #b49368
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-xcode-dusk-256.Xresources
+++ b/xresources/base16-xcode-dusk-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #b21889
 #define base0F #c77c48
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-xcode-dusk.Xresources
+++ b/xresources/base16-xcode-dusk.Xresources
@@ -18,28 +18,28 @@
 #define base0E #b21889
 #define base0F #c77c48
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/xresources/base16-zenburn-256.Xresources
+++ b/xresources/base16-zenburn-256.Xresources
@@ -18,37 +18,37 @@
 #define base0E #dc8cc3
 #define base0F #000000
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/xresources/base16-zenburn.Xresources
+++ b/xresources/base16-zenburn.Xresources
@@ -18,28 +18,28 @@
 #define base0E #dc8cc3
 #define base0F #000000
 
-*.foreground:   base05
+*foreground:   base05
 #ifdef background_opacity
-*.background:   [background_opacity]base00
+*background:   [background_opacity]base00
 #else
-*.background:   base00
+*background:   base00
 #endif
-*.cursorColor:  base05
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07


### PR DESCRIPTION
#23 
Switched from `*.key` to `*key` and rebuilt for all current colorschemes to confirm to the Xresources syntax definition and for wider application support.